### PR TITLE
Add new properties to CustomerShipmentProducts, fix for CustomerOrders

### DIFF
--- a/GoSweetSpotApiClientLib/GoSweetSpotApiClient.cs
+++ b/GoSweetSpotApiClientLib/GoSweetSpotApiClient.cs
@@ -27,7 +27,7 @@ namespace GoSweetSpotApiClientLib
         }
         public async Task<List<CustomerOrder>> CustomerOrders_GetAsync(DateTime createdFrom, DateTime createdTo, bool excludecompleted, bool includeProducts = false)
         {
-            return await CustomerOrders_GetFilteredAsync(null, createdFrom, createdTo, excludecompleted, includeProducts);
+            return await CustomerOrders_GetFilteredAsync(new List<string>(), createdFrom, createdTo, excludecompleted, includeProducts);
         }
         private async Task<List<CustomerOrder>> CustomerOrders_GetFilteredAsync(List<string> ordernumbers, DateTime? createdFrom, DateTime? createdTo, bool excludecompleted, bool includeProducts)
         {

--- a/GoSweetSpotApiClientLib/Models/CustomerOrder.cs
+++ b/GoSweetSpotApiClientLib/Models/CustomerOrder.cs
@@ -42,6 +42,8 @@ namespace GoSweetSpotApiClientLib.Models
             public decimal UnitKg { get; set; }
             public string ImageUrl { get; set; }
             public string Currency { get; set; }
+            public decimal AlreadySent { get; set; }
+            public decimal? FulfilledQty { get; set; }
         }
     }
 }


### PR DESCRIPTION
Added new properties AlreadySent and FulfilledQty to CustomerShipmentProducts, so that these can be sent and received from the API.

CustomerOrders endpoint is fixed for when no order numbers are supplied.