### PR TITLE
4489 Add ConsignmentItem.MarkedUp_LineTotal to /api/shipment API response

### DIFF
--- a/GoSweetSpotApiClientLib/Models/ShipmentStatusFull.cs
+++ b/GoSweetSpotApiClientLib/Models/ShipmentStatusFull.cs
@@ -90,6 +90,7 @@ namespace GoSweetSpotApiClientLib.Models
             public decimal WeightKg { get; set; }
             public string PackageName { get; set; }
             public decimal Charge_LineTotal { get; set; }
+            public decimal Charge_MarkedUpLineTotal { get; set; }
             public DateTime? PickedAt { get; set; }
             public DateTime? DeliveredAt { get; set; }
             public string RatingCode {get;set;}


### PR DESCRIPTION
Add ConsignmentItem.MarkedUp_LineTotal property for new field in /api/shipment API response.

Note: only documented for GET /api/shipment response, not POST /api/shipment response, because the latter has no sectino for consignment items at all.

# Impacts:
Users: **New and updated API client users** 
Systems: **Ship API client** 

# Merge Considerations:
EDMX Changes? **No**
Are database changes backwards compatible? **N/A**
Are there any schematic changes that could cause blocks? Frequently used tables? **N/A**

# Testing:


# Deployment Steps:
Should be deployed AFTER PR 2765 on Azure DevOps.

**Deployment plan:**

**Risks**
No risk.

**Rollback plan:** 
Will IIS rollback be sufficient? **N/A**
Will DB rollback be sufficient? **N/A**

# Configuration:
Are there any new Feature switches are config settings introduced? **No**
If Yes - does this require devops pipeline, octopus deploy changes? **N/A**
	If Yes - Have the changes been made? **N/A**
